### PR TITLE
Fix TypeError with PHP 8

### DIFF
--- a/src/View/Helper/FlashMessenger.php
+++ b/src/View/Helper/FlashMessenger.php
@@ -332,7 +332,7 @@ class FlashMessenger extends AbstractHelper
             return $this->escapeHtmlHelper;
         }
 
-        if (method_exists($this->getView(), 'plugin')) {
+        if ($this->getView() && method_exists($this->getView(), 'plugin')) {
             $this->escapeHtmlHelper = $this->view->plugin('escapehtml');
         }
 


### PR DESCRIPTION
```
Runtime:       PHP 8.0.4RC1
Configuration: /dev/shm/BUILD/laminas-mvc-plugin-flashmessenger-f5a522c3aab215a9b89a0630beb91582f4a3f202/phpunit.xml.dist

...............................................                   47 / 47 (100%)

Time: 49 ms, Memory: 4.00 MB

OK (47 tests, 195 assertions)

```