### PR TITLE
Added support for PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     },
     "require": {
-        "php": "^7.3 || ~8.0.0",
+        "php": "^7.3 || ~8.0.0 || ~8.1.0",
         "laminas/laminas-mvc": "^3.0",
         "laminas/laminas-session": "^2.8.5",
         "laminas/laminas-stdlib": "^3.2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "642ec4c0f97f20a76c414392ef9636eb",
+    "content-hash": "1fa9ddff5c164183bc85b31bbe86efca",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -3659,8 +3659,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.3 || ~8.0.0"
+        "php": "^7.3 || ~8.0.0 || ~8.1.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/src/FlashMessenger.php
+++ b/src/FlashMessenger.php
@@ -15,6 +15,7 @@ use Laminas\Mvc\Controller\Plugin\AbstractPlugin;
 use Laminas\Session\Container;
 use Laminas\Session\ManagerInterface as Manager;
 use Laminas\Stdlib\SplQueue;
+use ReturnTypeWillChange;
 
 /**
  * Flash Messenger - implement session-based messages
@@ -592,6 +593,7 @@ class FlashMessenger extends AbstractPlugin implements IteratorAggregate, Counta
      *
      * @return ArrayIterator
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         if ($this->hasMessages()) {
@@ -606,6 +608,7 @@ class FlashMessenger extends AbstractPlugin implements IteratorAggregate, Counta
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         if ($this->hasMessages()) {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description
This PR adds support for PHP 8.1. No big changes had to be made luckily. I ran a code inspection indicating no compatibility issues. Moreover, all tests are passing.
This fixes #17 

```
/bin/php8.1 /home/koen/laminas-mvc-plugin-flashmessenger/vendor/phpunit/phpunit/phpunit --configuration /home/koen/laminas-mvc-plugin-flashmessenger/phpunit.xml.dist /home/koen/laminas-mvc-plugin-flashmessenger/test --teamcity
Testing started at 19:31 ...
PHPUnit 9.5.10 by Sebastian Bergmann and contributors.



Time: 00:00.061, Memory: 8.00 MB

OK (47 tests, 195 assertions)
Process finished with exit code 0
```