### PR TITLE
feat(docs): fixed template of rendering success flash messages

### DIFF
--- a/docs/book/basic-usage.md
+++ b/docs/book/basic-usage.md
@@ -30,10 +30,10 @@ class AlbumController extends AbstractActionController
 
 ## Render a Flash Message
 
-Render all flash messages in a view script, e.g. `module/Album/view/album/album/index.phtml`:
+Render success type of flash messages in a view script, e.g. `module/Album/view/album/album/index.phtml`:
 
 ```php
-<?= $this->flashMessenger()->render() ?>
+<?= $this->flashMessenger()->render(FlashMessenger::NAMESPACE_SUCCESS) ?>
 ```
 
 Output:


### PR DESCRIPTION

Docs section "Basic usage" from 1.10.x has mistake in part "Render a Flash Message", because we can't render success message by <?= $this->flashMessenger()->render() ?>

https://docs.laminas.dev/laminas-mvc-plugin-flashmessenger/basic-usage/
![image](https://github.com/laminas/laminas-mvc-plugin-flashmessenger/assets/8617791/40b306ee-74d6-4664-adb8-fb4962033b71)


|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

  - TARGET THE docs Basic usage  1.10.x branch has mistake example of rendering success flash messages
